### PR TITLE
Add ML-inspired horse odds backend

### DIFF
--- a/all-star-ml-backend/app.py
+++ b/all-star-ml-backend/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, request, jsonify
+import json
+import math
 import joblib
 from flask_cors import CORS
 
@@ -6,6 +8,33 @@ app = Flask(__name__)
 CORS(app)
 
 model = joblib.load("engagement_model.pkl")
+
+# Load horse attributes used for the odds and personality endpoint
+with open("horse_data.json", "r", encoding="utf-8") as f:
+    HORSE_DATA = json.load(f)
+
+
+def calculate_horse_odds(data):
+    """Return list of horses with odds based on simple weighted score."""
+    # compute a weighted score for each horse
+    weights = []
+    for h in data:
+        score = 0.4 * h["speed"] + 0.3 * h["endurance"] + 0.3 * h["experience"]
+        weights.append(score)
+
+    total = sum(weights)
+    odds = []
+    for h, w in zip(data, weights):
+        prob = w / total if total else 0.0
+        # convert probability to fractional odds for display
+        fractional = (1 - prob) / prob if prob else 0.0
+        odds.append({
+            "name": h["name"],
+            "odds": round(fractional, 2),
+            "personality": h["personality"],
+            "probability": round(prob, 3),
+        })
+    return odds
 
 @app.route("/predict_next_action", methods=["POST"])
 def predict_next_action():
@@ -18,6 +47,13 @@ def predict_next_action():
     ]
     predicted_action = model.predict([features])[0]
     return jsonify({"next_action": predicted_action})
+
+
+@app.route("/horse_odds", methods=["GET"])
+def horse_odds():
+    """Endpoint returning odds and personalities for horses."""
+    odds = calculate_horse_odds(HORSE_DATA)
+    return jsonify(odds)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/all-star-ml-backend/horse_data.json
+++ b/all-star-ml-backend/horse_data.json
@@ -1,0 +1,6 @@
+[
+  {"name": "Thunderbolt ⚡", "speed": 90, "endurance": 80, "experience": 70, "personality": "Aggressive"},
+  {"name": "Golden Mane 🌟", "speed": 85, "endurance": 85, "experience": 60, "personality": "Calm"},
+  {"name": "Midnight Runner 🌙", "speed": 80, "endurance": 70, "experience": 80, "personality": "Steady"},
+  {"name": "Red Comet ☄️", "speed": 88, "endurance": 75, "experience": 65, "personality": "Fiery"}
+]

--- a/src/HorseRace.jsx
+++ b/src/HorseRace.jsx
@@ -1,20 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import axios from 'axios';
 
-const horses = ['Thunderbolt ⚡', 'Golden Mane 🌟', 'Midnight Runner 🌙', 'Red Comet ☄️'];
+const API_URL = 'http://localhost:5000/horse_odds';
 
 const HorseRace = () => {
   const [bets, setBets] = useState({});
   const [raceOn, setRaceOn] = useState(false);
   const [winner, setWinner] = useState('');
+  const [horses, setHorses] = useState([]);
 
-  const placeBet = (horse) => {
-    setBets((prev) => ({ ...prev, [horse]: (prev[horse] || 0) + 10 }));
+  useEffect(() => {
+    axios.get(API_URL)
+      .then(res => {
+        setHorses(res.data);
+      })
+      .catch(err => console.error('Failed to fetch horse data', err));
+  }, []);
+
+  const placeBet = (horseName) => {
+    setBets((prev) => ({ ...prev, [horseName]: (prev[horseName] || 0) + 10 }));
   };
 
   const startRace = () => {
     setRaceOn(true);
-    const winningHorse = horses[Math.floor(Math.random() * horses.length)];
+    const winningHorse = horses[Math.floor(Math.random() * horses.length)].name;
     setTimeout(() => {
       setRaceOn(false);
       setWinner(winningHorse);
@@ -25,15 +35,17 @@ const HorseRace = () => {
     <div className="p-6 bg-green-500 rounded-xl shadow-xl">
       <h2 className="text-3xl font-bold text-white mb-4">🏇 Live Horse Racing!</h2>
       <div className="mb-4 space-y-2">
-        {horses.map((horse, i) => (
-          <div key={horse} className="flex items-center">
-            <button 
-              onClick={() => placeBet(horse)} 
+        {horses.map((horse) => (
+          <div key={horse.name} className="flex items-center">
+            <button
+              onClick={() => placeBet(horse.name)}
               className="px-3 py-1 bg-yellow-400 hover:bg-yellow-500 rounded-md shadow mr-4"
             >
               Bet 10 🪙
             </button>
-            <span>{horse} (Bet: {bets[horse] || 0} 🪙)</span>
+            <span>
+              {horse.name} - {horse.personality} (Odds: {horse.odds}:1, Bet: {bets[horse.name] || 0} 🪙)
+            </span>
           </div>
         ))}
       </div>
@@ -46,15 +58,15 @@ const HorseRace = () => {
 
       {raceOn && (
         <div className="mt-6">
-          {horses.map((horse, i) => (
+          {horses.map((horse) => (
             <motion.div
-              key={horse}
+              key={horse.name}
               initial={{ x: 0 }}
               animate={{ x: '80vw' }}
               transition={{ duration: Math.random() * 3 + 2 }}
               className="mb-2 text-xl"
             >
-              {horse}
+              {horse.name}
             </motion.div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- implement `horse_odds` endpoint in Flask backend
- compute odds from new `horse_data.json`
- fetch odds/personality in HorseRace component

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877132529a4832798f568517730e2af