### PR TITLE
Add real-time leaderboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import AllStarVibe from './allstarvibe';
 import HorseRace from './HorseRace';
+import Leaderboard from './Leaderboard';
 import './App.css';
 
 function App() {
@@ -8,6 +9,7 @@ function App() {
     <div className="App space-y-8 p-8 bg-gray-100 min-h-screen">
       <AllStarVibe />
       <HorseRace />
+      <Leaderboard />
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders All-Star Vibe heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/All-Star Vibe/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/Leaderboard.jsx
+++ b/src/Leaderboard.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+
+const initialPlayers = [
+  { name: 'Player One', score: 120 },
+  { name: 'Player Two', score: 95 },
+  { name: 'Player Three', score: 80 },
+  { name: 'Player Four', score: 60 },
+];
+
+const Leaderboard = () => {
+  const [players, setPlayers] = useState(initialPlayers);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPlayers(prev => prev.map(p => ({
+        ...p,
+        score: p.score + Math.floor(Math.random() * 5),
+      })).sort((a,b) => b.score - a.score));
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-white p-6 rounded-2xl shadow-xl max-w-md w-full mx-auto">
+      <h2 className="text-2xl font-bold mb-4 text-center">🏅 Live Leaderboard</h2>
+      <ul className="space-y-2">
+        {players.map((player, idx) => (
+          <li key={player.name} className="flex justify-between">
+            <span>
+              {idx + 1}. {player.name}
+            </span>
+            <span className="font-semibold">{player.score}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Leaderboard;


### PR DESCRIPTION
## Summary
- create a new `Leaderboard` component that updates scores every few seconds
- show the leaderboard in `App`
- update tests to look for the All-Star Vibe heading

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877133deacc83279d855ad0294f6d45