### PR TITLE
Add note on port 3000 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ In the project directory, you can run:
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 
+When running the app with **Bun** or using **Vite**'s preview server make sure
+the process listens on **port 3000**. This matches the `internal_port` value
+defined in `fly.toml` for deployment on Fly.io.
+
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,5 @@
+app = "all-star-game"
+
+[[services]]
+  internal_port = 3000
+  protocol = "tcp"


### PR DESCRIPTION
## Summary
- document that Bun/Vite should run on port 3000 for Fly.io
- add example fly.toml configuration

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6889a5f5d72083278679160c17c883c8